### PR TITLE
Add: お知らせ登録機能・日本語翻訳

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 
+gem 'rails-i18n', '~> 6.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.1.4.1)
       actionpack (= 6.1.4.1)
       activesupport (= 6.1.4.1)
@@ -184,6 +187,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4, >= 6.1.4.1)
+  rails-i18n (~> 6.0)
   sass-rails (>= 6)
   spring
   sqlite3 (~> 1.4)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,9 @@ class ApplicationController < ActionController::Base
   include SessionsHelper
 
   before_action :user_logged_in?
-  
+
+  add_flash_types :success, :info, :warning, :danger
+
   private
     def user_logged_in?
       return if logged_in?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,9 @@ class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
 
   private
-    def user_logged_in?
-      return if logged_in?
-      redirect_to login_path
-    end
+
+  def user_logged_in?
+    return if logged_in?
+    redirect_to login_path
+  end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -13,7 +13,10 @@ class ArticlesController < ApplicationController
     @article = Article.new(article_params)
 
     if @article.save
-      redirect_to employees_url, notice: "記事「#{@article.title}」を登録しました。"
+      redirect_to articles_url, success: t('.success', item: @article.title)
+    else
+      flash.now[:danger] = t('.fail')
+      render :new
     end
   end
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,7 +1,7 @@
 class Article < ApplicationRecord
   belongs_to :employee, foreign_key: 'author'
 
-  validates :title, presence: true
+  validates :title, presence: true, length: { maximum: 50 }
   validates :content, presence: true
   validates :author, presence: true
 

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -19,5 +19,7 @@
       <%= f.text_field :content %>
     </div>
 
+    <%= f.hidden_field :author, :value => current_user.id %>
+
   <% end %>
 </div>

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,12 +1,4 @@
 <div class="article_form">
-  <% if article.errors.present? %>
-    <ul>
-      <% article.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
-  <% end %>
-
   <%= form_with model: article, local: true do |f| %>
     <%= f.submit '保存' %>
 

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,0 +1,23 @@
+<div class="article_form">
+  <% if article.errors.present? %>
+    <ul>
+      <% article.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <%= form_with model: article, local: true do |f| %>
+    <%= f.submit '保存' %>
+
+    <div class="form_group">
+      <%= f.label :title %>
+      <%= f.text_field :title %>
+    </div>
+
+    <div class="form_group">
+      <%= f.text_field :content %>
+    </div>
+
+  <% end %>
+</div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,8 +1,4 @@
 <div class="article_index">
-  <% if flash.notice.present? %>
-    <p><%= flash.notice %></p>
-  <% end %>
-
   <% if current_user.employee_info_manage_auth %>
     <p class="new_article"><%= link_to '新規追加', new_article_path, class: 'btn' %></p>
   <% end %>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,2 +1,1 @@
-<h1>Articles#new</h1>
-<p>Find me in app/views/articles/new.html.erb</p>
+<%= render partial: 'form', locals: { article: @article } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,8 +13,8 @@
     <% if logged_in? %>
       <%= render 'layouts/header' %>
     <% end %>
+    <%= render 'shared/flash_message' %>
     <div class='container'>
-      <%= render 'shared/flash_message' %>
       <%= yield %>
     </div>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
       <%= render 'layouts/header' %>
     <% end %>
     <div class='container'>
+      <%= render 'shared/flash_message' %>
       <%= yield %>
     </div>
   </body>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,3 @@
+<% flash.each do |message| %>
+  <div><%= message %></div>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,7 @@ module NewsAndEmployeeIntroduction
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
     config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,21 +1,5 @@
 ja:
   activerecord:
-    errors:
-      messages:
-        record_invalid: "バリエーションに失敗しました: %{errors}"
-        restrict_dependent_destroy:
-          has_one: "%{record}が存在しているので削除できません"
-          has_many: "%{record}が存在しているので削除できません"
-        required: を入力してください
-        blank: を入力してください
-        too_long: は%{count}文字以内で入力してください
-        too_short: は%{count}文字以上で入力してください
-        taken: はすでに存在します
-      models:
-        profile:
-          attributes:
-            profile:
-              too_short: を入力してください
     models:
       employee: 社員
       department: 部署
@@ -39,3 +23,5 @@ ja:
         profile: プロフィール
       article:
         title: タイトル
+        content: 内容
+        author: 投稿者

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,6 +21,7 @@ ja:
       department: 部署
       office: オフィス
       profile: プロフィール
+      article: 記事
     attributes:
       employee:
         number: 社員番号
@@ -36,3 +37,5 @@ ja:
         news_posting_auth: お知らせ投稿権限
       profile:
         profile: プロフィール
+      article:
+        title: タイトル

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  articles:
+    create:
+      success: "記事「%{item}」を登録しました"
+      fail: 記事の作成に失敗しました
+  errors:
+    messages:
+      blank: が入力されていません


### PR DESCRIPTION
### 概要

- お知らせ（記事）の登録機能の追加
- 日本語翻訳（gem rails-i18nの適用）
- フラッシュメッセージのテンプレート化

close #4 

### 影響範囲

お知らせ機能のみ

### 確認方法

1. gemを追加しました。`bundle install`を実行してください。

### To Do
- [x]  お知らせの登録ができる。
- [x]  保存ボタンをクリックしたとき、バリデーションチェックを行う。
- [x]  タイトル：入力されているか？ ： "タイトルが入力されていません"
- [x]  タイトル：50文字以内か？ ： "タイトルは50文字以内で入力してください"
- [x]  登録した後、一覧画面に遷移する。